### PR TITLE
Add BuiltWithDot.Net badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 [![Reflection NuGet Version](https://img.shields.io/nuget/v/NetFabric.Reflection.svg?style=flat-square&label=Reflection%20nuget&logo=nuget)](https://www.nuget.org/packages/NetFabric.Reflection/)
 [![Reflection NuGet Downloads](https://img.shields.io/nuget/dt/NetFabric.Reflection.svg?style=flat-square&label=Reflection%20downloads&logo=nuget)](https://www.nuget.org/packages/NetFabric.Reflection/)
+[![BuiltWithDot.Net shield](https://builtwithdot.net/project/509/netfabric-codeanalysis-csharp-net-core/badge)](https://builtwithdot.net/project/509/netfabric-codeanalysis-csharp-net-core)
 
 # NetFabric.CodeAnalysis and NetFabric.Reflection Documentation
 


### PR DESCRIPTION
Since NetFabric.CodeAnalysis is listed on BuiltWithDot.Net I've taken the liberty to raise a PR that adds the BuiltWithDot.Net badge for NetFabric.CodeAnalysis to the README.md file. This will help promote your project, BuiltWithDot.Net, all other .NET developers that have projects listed on the site, and the open-source .NET ecosystem in general. If you have any questions or concerns, please let me know. Your help is much appreciated!

Thanks, Corstiaan (creator of BuiltWithDot.Net)

PS If you don't want to add the badge, that's totally fine. Just close this PR. No hard feelings :-)